### PR TITLE
Update stringCheck to remove formatting tags from t10 names

### DIFF
--- a/commands/formatting/T10Commands.py
+++ b/commands/formatting/T10Commands.py
@@ -1,6 +1,7 @@
 import requests
 import asyncio
 import json
+import re
 from datetime import datetime
 from datetime import timedelta
 from pytz import timezone
@@ -469,10 +470,10 @@ async def t10membersformatting(server: str, eventid: int, songs: bool, userid):
 
 
 def stringCheck(string: str):
-    if "```" in string:
-        string = string.replace('```','')
-    if "?" in string:
-        string = string.replace("?",'')
+    string = string.replace('```','')
+    string = string.replace("?",'')
+    string = re.sub('(\[\w{6}\])','', string)
+    string = re.sub('\[([cibsu]|(sup|sub){1})\]', '', string)
     return string
 
 


### PR DESCRIPTION
This removes the formatting tags such as [i] [b] [u] [s] [sup] [sub] and all hex color codes from the t10 names, which helps with their readability in the text format of discord. Also removes unnecessary if statements.